### PR TITLE
Create previews for components derived from the former Pane component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
   PersonalDetailsPreview,
 } from "./components/PersonalDetails";
 import { Qualifications } from "./components/Qualifications";
-import { References } from "./components/References";
+import { References, ReferencesPreview } from "./components/References";
 import { Skills, SkillsPreview } from "./components/Skills";
 
 function App() {
@@ -28,6 +28,7 @@ function App() {
         <p className="text-center font-medium text-xl">Resume</p>
         <PersonalDetailsPreview />
         <EducationPreview />
+        <ReferencesPreview />
         <SkillsPreview />
         <EmploymentPreview />
         <CertificatesPreview />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,10 @@ import {
   PersonalDetails,
   PersonalDetailsPreview,
 } from "./components/PersonalDetails";
-import { Qualifications } from "./components/Qualifications";
+import {
+  Qualifications,
+  QualificationsPreview,
+} from "./components/Qualifications";
 import { References, ReferencesPreview } from "./components/References";
 import { Skills, SkillsPreview } from "./components/Skills";
 
@@ -28,6 +31,7 @@ function App() {
         <p className="text-center font-medium text-xl">Resume</p>
         <PersonalDetailsPreview />
         <EducationPreview />
+        <QualificationsPreview />
         <InterestsPreview />
         <ReferencesPreview />
         <SkillsPreview />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import {
 } from "./components/PersonalDetails";
 import { Qualifications } from "./components/Qualifications";
 import { References } from "./components/References";
-import { Skills } from "./components/Skills";
+import { Skills, SkillsPreview } from "./components/Skills";
 
 function App() {
   return (
@@ -28,6 +28,7 @@ function App() {
         <p className="text-center font-medium text-xl">Resume</p>
         <PersonalDetailsPreview />
         <EducationPreview />
+        <SkillsPreview />
         <EmploymentPreview />
         <CertificatesPreview />
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Certificates, CertificatesPreview } from "./components/Certificates";
 import { Education, EducationPreview } from "./components/Education";
 import { Employment, EmploymentPreview } from "./components/Employment";
-import { Interests } from "./components/Interests";
+import { Interests, InterestsPreview } from "./components/Interests";
 import {
   PersonalDetails,
   PersonalDetailsPreview,
@@ -28,6 +28,7 @@ function App() {
         <p className="text-center font-medium text-xl">Resume</p>
         <PersonalDetailsPreview />
         <EducationPreview />
+        <InterestsPreview />
         <ReferencesPreview />
         <SkillsPreview />
         <EmploymentPreview />

--- a/src/components/Interests.tsx
+++ b/src/components/Interests.tsx
@@ -1,8 +1,18 @@
 import { useForm } from "react-hook-form";
+import { create } from "zustand";
 
 type State = {
   description: string;
 };
+
+type Action = {
+  updateDescription: (description: State["description"]) => void;
+};
+
+const useStore = create<State & Action>()((set) => ({
+  description: "",
+  updateDescription: (description) => set(() => ({ description: description })),
+}));
 
 export function Interests() {
   const { register } = useForm<State>();

--- a/src/components/Interests.tsx
+++ b/src/components/Interests.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent } from "react";
 import { useForm } from "react-hook-form";
 import { create } from "zustand";
 
@@ -16,6 +17,7 @@ const useStore = create<State & Action>()((set) => ({
 
 export function Interests() {
   const { register } = useForm<State>();
+  const updateDescription = useStore((state) => state.updateDescription);
 
   return (
     <details
@@ -35,7 +37,11 @@ export function Interests() {
         <label className="block w-full">
           <span className="font-medium">Description</span>
           <textarea
-            {...register("description", { required: true })}
+            {...register("description", {
+              required: true,
+              onChange: (e: ChangeEvent<HTMLTextAreaElement>) =>
+                updateDescription(e.target.value),
+            })}
             cols={80}
             rows={10}
             className="bg-gray-100 rounded-lg border-none w-full"

--- a/src/components/Interests.tsx
+++ b/src/components/Interests.tsx
@@ -3,21 +3,21 @@ import { useForm } from "react-hook-form";
 import { create } from "zustand";
 
 type State = {
-  description: string;
+  interests: string;
 };
 
 type Action = {
-  updateDescription: (description: State["description"]) => void;
+  updateInterests: (description: State["interests"]) => void;
 };
 
 const useStore = create<State & Action>()((set) => ({
-  description: "",
-  updateDescription: (description) => set(() => ({ description: description })),
+  interests: "",
+  updateInterests: (interests) => set(() => ({ interests: interests })),
 }));
 
 export function Interests() {
   const { register } = useForm<State>();
-  const updateDescription = useStore((state) => state.updateDescription);
+  const updateInterests = useStore((state) => state.updateInterests);
 
   return (
     <details
@@ -37,10 +37,10 @@ export function Interests() {
         <label className="block w-full">
           <span className="font-medium">Description</span>
           <textarea
-            {...register("description", {
+            {...register("interests", {
               required: true,
               onChange: (e: ChangeEvent<HTMLTextAreaElement>) =>
-                updateDescription(e.target.value),
+                updateInterests(e.target.value),
             })}
             cols={80}
             rows={10}
@@ -53,7 +53,7 @@ export function Interests() {
 }
 
 export function InterestsPreview() {
-  const description = useStore((state) => state.description);
+  const interests = useStore((state) => state.interests);
 
-  return <>{description}</>;
+  return <>{interests}</>;
 }

--- a/src/components/Interests.tsx
+++ b/src/components/Interests.tsx
@@ -51,3 +51,9 @@ export function Interests() {
     </details>
   );
 }
+
+export function InterestsPreview() {
+  const description = useStore((state) => state.description);
+
+  return <>{description}</>;
+}

--- a/src/components/Qualifications.tsx
+++ b/src/components/Qualifications.tsx
@@ -51,3 +51,9 @@ export function Qualifications() {
     </details>
   );
 }
+
+export function QualificationsPreview() {
+  const description = useStore((state) => state.description);
+
+  return <>{description}</>;
+}

--- a/src/components/Qualifications.tsx
+++ b/src/components/Qualifications.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent } from "react";
 import { useForm } from "react-hook-form";
 import { create } from "zustand";
 
@@ -16,6 +17,7 @@ const useStore = create<State & Action>()((set) => ({
 
 export function Qualifications() {
   const { register } = useForm<State>();
+  const updateDescription = useStore((state) => state.updateDescription);
 
   return (
     <details
@@ -35,7 +37,11 @@ export function Qualifications() {
         <label className="block w-full">
           <span className="font-medium">Description</span>
           <textarea
-            {...register("description", { required: true })}
+            {...register("description", {
+              required: true,
+              onChange: (e: ChangeEvent<HTMLTextAreaElement>) =>
+                updateDescription(e.target.value),
+            })}
             cols={80}
             rows={10}
             className="bg-gray-100 rounded-lg border-none w-full"

--- a/src/components/Qualifications.tsx
+++ b/src/components/Qualifications.tsx
@@ -36,7 +36,7 @@ export function Qualifications() {
 
       <form action="/" method="post" autoComplete="off" className="rounded-lg">
         <label className="block w-full">
-          <span className="font-medium">Qualifications</span>
+          <span className="font-medium">Description</span>
           <textarea
             {...register("qualifications", {
               required: true,

--- a/src/components/Qualifications.tsx
+++ b/src/components/Qualifications.tsx
@@ -1,8 +1,18 @@
 import { useForm } from "react-hook-form";
+import { create } from "zustand";
 
 type State = {
   description: string;
 };
+
+type Action = {
+  updateDescription: (description: State["description"]) => void;
+};
+
+const useStore = create<State & Action>()((set) => ({
+  description: "",
+  updateDescription: (description) => set(() => ({ description: description })),
+}));
 
 export function Qualifications() {
   const { register } = useForm<State>();

--- a/src/components/Qualifications.tsx
+++ b/src/components/Qualifications.tsx
@@ -3,21 +3,22 @@ import { useForm } from "react-hook-form";
 import { create } from "zustand";
 
 type State = {
-  description: string;
+  qualifications: string;
 };
 
 type Action = {
-  updateDescription: (description: State["description"]) => void;
+  updateQualifications: (description: State["qualifications"]) => void;
 };
 
 const useStore = create<State & Action>()((set) => ({
-  description: "",
-  updateDescription: (description) => set(() => ({ description: description })),
+  qualifications: "",
+  updateQualifications: (qualifications) =>
+    set(() => ({ qualifications: qualifications })),
 }));
 
 export function Qualifications() {
   const { register } = useForm<State>();
-  const updateDescription = useStore((state) => state.updateDescription);
+  const updateQualifications = useStore((state) => state.updateQualifications);
 
   return (
     <details
@@ -35,12 +36,12 @@ export function Qualifications() {
 
       <form action="/" method="post" autoComplete="off" className="rounded-lg">
         <label className="block w-full">
-          <span className="font-medium">Description</span>
+          <span className="font-medium">Qualifications</span>
           <textarea
-            {...register("description", {
+            {...register("qualifications", {
               required: true,
               onChange: (e: ChangeEvent<HTMLTextAreaElement>) =>
-                updateDescription(e.target.value),
+                updateQualifications(e.target.value),
             })}
             cols={80}
             rows={10}
@@ -53,7 +54,7 @@ export function Qualifications() {
 }
 
 export function QualificationsPreview() {
-  const description = useStore((state) => state.description);
+  const qualifications = useStore((state) => state.qualifications);
 
-  return <>{description}</>;
+  return <>{qualifications}</>;
 }

--- a/src/components/References.tsx
+++ b/src/components/References.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent } from "react";
 import { useForm } from "react-hook-form";
 import { create } from "zustand";
 
@@ -16,6 +17,7 @@ const useStore = create<State & Action>()((set) => ({
 
 export function References() {
   const { register } = useForm<State>();
+  const updateDescription = useStore((state) => state.updateDescription);
 
   return (
     <details
@@ -35,7 +37,11 @@ export function References() {
         <label className="block w-full">
           <span className="font-medium">Description</span>
           <textarea
-            {...register("description", { required: true })}
+            {...register("description", {
+              required: true,
+              onChange: (e: ChangeEvent<HTMLTextAreaElement>) =>
+                updateDescription(e.target.value),
+            })}
             cols={80}
             rows={10}
             className="bg-gray-100 rounded-lg border-none w-full"

--- a/src/components/References.tsx
+++ b/src/components/References.tsx
@@ -1,8 +1,18 @@
 import { useForm } from "react-hook-form";
+import { create } from "zustand";
 
 type State = {
   description: string;
 };
+
+type Action = {
+  updateDescription: (description: State["description"]) => void;
+};
+
+const useStore = create<State & Action>()((set) => ({
+  description: "",
+  updateDescription: (description) => set(() => ({ description: description })),
+}));
 
 export function References() {
   const { register } = useForm<State>();

--- a/src/components/References.tsx
+++ b/src/components/References.tsx
@@ -51,3 +51,9 @@ export function References() {
     </details>
   );
 }
+
+export function ReferencesPreview() {
+  const description = useStore((state) => state.description);
+
+  return <>{description}</>;
+}

--- a/src/components/References.tsx
+++ b/src/components/References.tsx
@@ -3,21 +3,21 @@ import { useForm } from "react-hook-form";
 import { create } from "zustand";
 
 type State = {
-  description: string;
+  references: string;
 };
 
 type Action = {
-  updateDescription: (description: State["description"]) => void;
+  updateReferences: (description: State["references"]) => void;
 };
 
 const useStore = create<State & Action>()((set) => ({
-  description: "",
-  updateDescription: (description) => set(() => ({ description: description })),
+  references: "",
+  updateReferences: (references) => set(() => ({ references: references })),
 }));
 
 export function References() {
   const { register } = useForm<State>();
-  const updateDescription = useStore((state) => state.updateDescription);
+  const updateReferences = useStore((state) => state.updateReferences);
 
   return (
     <details
@@ -37,10 +37,10 @@ export function References() {
         <label className="block w-full">
           <span className="font-medium">Description</span>
           <textarea
-            {...register("description", {
+            {...register("references", {
               required: true,
               onChange: (e: ChangeEvent<HTMLTextAreaElement>) =>
-                updateDescription(e.target.value),
+                updateReferences(e.target.value),
             })}
             cols={80}
             rows={10}
@@ -53,7 +53,7 @@ export function References() {
 }
 
 export function ReferencesPreview() {
-  const description = useStore((state) => state.description);
+  const references = useStore((state) => state.references);
 
-  return <>{description}</>;
+  return <>{references}</>;
 }

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -3,21 +3,21 @@ import { useForm } from "react-hook-form";
 import { create } from "zustand";
 
 type State = {
-  description: string;
+  skills: string;
 };
 
 type Action = {
-  updateDescription: (description: State["description"]) => void;
+  updateSkills: (description: State["skills"]) => void;
 };
 
 const useStore = create<State & Action>()((set) => ({
-  description: "",
-  updateDescription: (description) => set(() => ({ description: description })),
+  skills: "",
+  updateSkills: (description) => set(() => ({ skills: description })),
 }));
 
 export function Skills() {
   const { register } = useForm<State>();
-  const updateDescription = useStore((state) => state.updateDescription);
+  const updateSkills = useStore((state) => state.updateSkills);
 
   return (
     <details
@@ -37,10 +37,10 @@ export function Skills() {
         <label className="block w-full">
           <span className="font-medium">Description</span>
           <textarea
-            {...register("description", {
+            {...register("skills", {
               required: true,
               onChange: (e: ChangeEvent<HTMLTextAreaElement>) =>
-                updateDescription(e.target.value),
+                updateSkills(e.target.value),
             })}
             cols={80}
             rows={10}
@@ -53,7 +53,7 @@ export function Skills() {
 }
 
 export function SkillsPreview() {
-  const description = useStore((state) => state.description);
+  const skills = useStore((state) => state.skills);
 
-  return <>{description}</>;
+  return <>{skills}</>;
 }

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -12,7 +12,7 @@ type Action = {
 
 const useStore = create<State & Action>()((set) => ({
   description: "",
-  updateDescription: (descrpition) => set(() => ({ description: descrpition })),
+  updateDescription: (description) => set(() => ({ description: description })),
 }));
 
 export function Skills() {

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,11 +1,23 @@
+import { ChangeEvent } from "react";
 import { useForm } from "react-hook-form";
+import { create } from "zustand";
 
 type State = {
   description: string;
 };
 
+type Action = {
+  updateDescription: (description: State["description"]) => void;
+};
+
+const useStore = create<State & Action>()((set) => ({
+  description: "",
+  updateDescription: (descrpition) => set(() => ({ description: descrpition })),
+}));
+
 export function Skills() {
   const { register } = useForm<State>();
+  const updateDescription = useStore((state) => state.updateDescription);
 
   return (
     <details
@@ -25,7 +37,11 @@ export function Skills() {
         <label className="block w-full">
           <span className="font-medium">Description</span>
           <textarea
-            {...register("description", { required: true })}
+            {...register("description", {
+              required: true,
+              onChange: (e: ChangeEvent<HTMLTextAreaElement>) =>
+                updateDescription(e.target.value),
+            })}
             cols={80}
             rows={10}
             className="bg-gray-100 rounded-lg border-none w-full"
@@ -34,4 +50,10 @@ export function Skills() {
       </form>
     </details>
   );
+}
+
+export function SkillsPreview() {
+  const description = useStore((state) => state.description);
+
+  return <>{description}</>;
 }


### PR DESCRIPTION
This PR creates preview components for the following components:
	1. Skills
	2. References
	3. Interests
	4. Qualifications

- **feat: add a SkillsPreview component**
- **feat: render SkillsPreview in App component**
- **chore: fix typo**
- **feat: create a store for References component state**
- **feat: write to References store on each change event**
- **feat: add a ReferencesPreview component**
- **feat: render the ReferencesPreview in the App component**
- **feat: create a store for the Interests component**
- **feat: update the Interests store's state on each change event**
- **feat: add InterestsPreview component**
- **feat: render InterestsPreview in App component**
- **feat: create a store for the Qualifications component's state**
- **feat: update the store's state on each change event fire**
- **feat: add QualificationsPreview component**
- **feat: render QualificationsPreview in App component**
- **refactor: rename Qualification's state variables**
- **refactor: rename Interests store state variables**
- **refactor: rename the variables in the References store**
- **refactor: rename the variables in the Skills store**
- **refactor: change the label of the Qualifications textarea element**
